### PR TITLE
Improve documentation

### DIFF
--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -81,9 +81,12 @@ include::{samplescodedir}/applying-plugins/declarative.gradle[]
 include::{samplescodedir}/applying-plugins/declarative.gradle.kts[]
 ----
 
-As you can see with the `jacoco` example, the same syntax can be used in Groovy and Kotlin, except for the double quotes and parentheses that must be used in Kotlin.
+The Kotlin DSL provides for all link:{user-manual}standard_plugins.html[Gradle core plugins] property extensions,
+as shown above with the `java`, `jacoco` or `maven-publish` declaration.
 
-The Kotlin DSL also defines Kotlin property extensions that you can use for all core Gradle plugins, as shown above with the `java` plugin declaration.
+Thirt party plugins can be applied similar like in the Groovy DSL. Except for the double quotes and parentheses.
+You could also apply core plugins with that style. But the statically-typed accessors are recommended since they are
+type-safe and will be autocompleted by your IDE.
 
 You can also use the imperative `apply` syntax, but then non-core plugins must be included on the classpath of the build script:
 

--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -84,7 +84,7 @@ include::{samplescodedir}/applying-plugins/declarative.gradle.kts[]
 The Kotlin DSL provides for all link:{user-manual}standard_plugins.html[Gradle core plugins] property extensions,
 as shown above with the `java`, `jacoco` or `maven-publish` declaration.
 
-Thirt party plugins can be applied similar like in the Groovy DSL. Except for the double quotes and parentheses.
+Third party plugins can be applied similar like in the Groovy DSL. Except for the double quotes and parentheses.
 You could also apply core plugins with that style. But the statically-typed accessors are recommended since they are
 type-safe and will be autocompleted by your IDE.
 

--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -81,9 +81,6 @@ include::{samplescodedir}/applying-plugins/declarative.gradle[]
 include::{samplescodedir}/applying-plugins/declarative.gradle.kts[]
 ----
 
-[TIP]
-You can switch between the Groovy and Kotlin versions of the script by clicking the tabs at the top of the sample.
-
 As you can see with the `jacoco` example, the same syntax can be used in Groovy and Kotlin, except for the double quotes and parentheses that must be used in Kotlin.
 
 The Kotlin DSL also defines Kotlin property extensions that you can use for all core Gradle plugins, as shown above with the `java` plugin declaration.

--- a/samples/code/applying-plugins/declarative.gradle
+++ b/samples/code/applying-plugins/declarative.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
     id 'jacoco'
+    id 'maven-publish'
     id 'org.springframework.boot' version '2.0.2.RELEASE'
 }

--- a/samples/code/applying-plugins/declarative.gradle.kts
+++ b/samples/code/applying-plugins/declarative.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     java
-    id("jacoco")
+    jacoco
+    `maven-publish`
     id("org.springframework.boot") version "2.0.2.RELEASE"
 }

--- a/samples/code/applying-plugins/imperative.gradle
+++ b/samples/code/applying-plugins/imperative.gradle
@@ -3,7 +3,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.0.2.RELEASE")
+        classpath('org.springframework.boot:spring-boot-gradle-plugin:2.0.2.RELEASE')
     }
 }
 

--- a/samples/code/configuring-plugins/declaratively-applied.gradle
+++ b/samples/code/configuring-plugins/declaratively-applied.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("jacoco")
+    id 'jacoco'
 }
 
 jacoco {

--- a/samples/code/configuring-plugins/declaratively-applied.gradle
+++ b/samples/code/configuring-plugins/declaratively-applied.gradle
@@ -3,5 +3,5 @@ plugins {
 }
 
 jacoco {
-    toolVersion = "0.8.1"
+    toolVersion = '0.8.1'
 }


### PR DESCRIPTION
I tried to fix some "issues" which were reported at #14.

* Remove the Tip
* Add info about accessors for core Gradle plugins.
I've also added the `maven-publish` example since they need the extra tick (`) .
