### PR TITLE
Fix Groovy lazy task creation example

### DIFF
--- a/samples/creating-tasks/tasks-lazy/groovy/build.gradle
+++ b/samples/creating-tasks/tasks-lazy/groovy/build.gradle
@@ -5,7 +5,7 @@ tasks.register('greeting') {
 // end::container-api[]
 
 // tag::typed-container-api[]
-tasks.create(name: 'docZip', type: Zip) {
+tasks.register('docZip', Zip) {
     archiveName = 'doc.zip'
     from 'doc'
 }


### PR DESCRIPTION
The example for Groovy showed using `tasks.create(...)` instead of `tasks.register(...)` for the lazy task creation example.